### PR TITLE
gemspec: Remove unused directives

### DIFF
--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -27,9 +27,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rack', '>= 2.1.4', '< 2.3.0'
 
   s.files       = `git ls-files`.split "\n"
-  s.test_files  = `git ls-files -- {test,spec,features}/*`.split "\n"
-  s.executables = `git ls-files -- bin/*`.split("\n")
-                                         .map { |f| File.basename f }
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 2.5'
 end


### PR DESCRIPTION
Closes: n/a

# Goal

Cleanup, leaner gemspec.

- `test_files` is not used in RubyGems.org, and
- this gem exposes no executables.

# Approach
1. Inspect the gemspec.
2. No changes need documentation.

