### PR TITLE
CI: use bundler-cache: true in test Workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     name: Ruby ${{ matrix.ruby-version }}
     strategy:
       matrix:
-        ruby-version: [2.5, 2.6, 2.7, "3.0"]
+        ruby-version: [2.5, 2.6, 2.7, '3.0']
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,10 @@ jobs:
   test:
     environment: staging
     runs-on: ubuntu-latest
+    name: Ruby ${{ matrix.ruby-version }}
     strategy:
       matrix:
-        ruby-version: [2.5, 2.6, 2.7, 3.0]
+        ruby-version: [2.5, 2.6, 2.7, "3.0"]
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -19,8 +20,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
-    - name: Install dependencies
-      run: bundle install
+        bundler-cache: true # 'bundle install' and cache
     - name: Run tests
       env:
         GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
@@ -30,4 +30,4 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Rubocop
-      run: bundle ex rubocop
+      run: bundle exec rubocop


### PR DESCRIPTION
Closes: n/a

# Goal

Cleanup CI configuration for test Workflow.


This PR uses the `bundler-cache` feature of the Ruby-maintained Action `ruby/setup-ruby`.

[See `ruby/setup-ruby` parameters declaration](https://github.com/ruby/setup-ruby/blob/master/action.yml) for more information.

In addition:

- Quote the 3.0 to avoid it turning into "3" when used.
- Name the Job.
- Spell `bundle exec` the same everywhere.

# Approach
1. Note that the CI configuraiton for tests didn't cache gems.
2. Make the change, documenting the oddities with code comments.


---

On Quoting:

This is a very small change, but which avoids a Float-to-String loss of characters.

An example (not from this project) of what it can look like before this change, in this picture:

<img width="376" alt="bild" src="https://user-images.githubusercontent.com/211/119782378-6ad6cd00-becc-11eb-9e13-9a425adaa054.png">

Read more details, if you like: https://github.com/actions/runner/issues/849