### PR TITLE
Attempt to stop using ActiveSupport

### DIFF
--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov', '~> 0.18'
   s.add_development_dependency 'simplecov-lcov', '~> 0.8'
 
-  s.add_runtime_dependency 'activesupport', '>= 4.1.11', '< 7.0'
   s.add_runtime_dependency 'rack', '>= 2.1.4', '< 2.3.0'
 
   s.files = `git ls-files`.split "\n"

--- a/lib/google_maps_geocoder/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder/google_maps_geocoder.rb
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 # frozen_string_literal: true
 
-require 'active_support'
+require 'json'
 require 'logger'
 require 'net/http'
 require 'rack'
@@ -71,7 +71,7 @@ class GoogleMapsGeocoder
     @json = address.is_a?(String) ? google_maps_response(address) : address
     status = @json && @json['status']
     raise RuntimeError if status == 'OVER_QUERY_LIMIT'
-    raise GeocodingError, @json if @json.blank? || status != 'OK'
+    raise GeocodingError, @json if !@json || (@json && @json.empty?) || status != 'OK'
 
     set_attributes_from_json
     Logger.new($stderr).info('GoogleMapsGeocoder') do
@@ -139,7 +139,7 @@ class GoogleMapsGeocoder
   def google_maps_response(address)
     uri = URI.parse google_maps_request(address)
     response = http(uri).request(Net::HTTP::Get.new(uri.request_uri))
-    ActiveSupport::JSON.decode response.body
+    JSON.parse(response.body, symbolize_names: true)
   end
 
   def http(uri)


### PR DESCRIPTION


Closes: n/a

# Goal

In order to have an even smaller dependency surface, this PR attempts to remove the ActiveSupport library dependency.


# Approach
1. Remove the gem dependency
2. See if the specs can pass (I lacked an API key locally, so I'm running the test suite using a Draft PR)
