### PR TITLE
CI: run on Pull Request, too

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 # Download the latest Ruby patch versions, install dependencies, and run tests.
 name: test
 on:
+  pull_request:
   push:
     paths-ignore:
       - '**.md'


### PR DESCRIPTION
Closes: #

# Goal
In order to see changes work/not work, let users run CI.

# Approach
1. Add CI event pull_request to the `test` Workflow.
