### PR TITLE
chore: Move development deps to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,11 @@
 
 source 'https://rubygems.org'
 gemspec
+
+gem 'rake', ['>= 12.3.3', '~> 13.0']
+gem 'rspec', '~> 3'
+gem 'rubocop', '< 1.24'
+gem 'rubocop-rake', '~> 0'
+gem 'rubocop-rspec', '~> 2'
+gem 'simplecov', '~> 0.18'
+gem 'simplecov-lcov', '~> 0.8'

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -15,14 +15,6 @@ Gem::Specification.new do |s|
   s.email = 'rod@foveacentral.com'
   s.signing_key = File.expand_path('~/.ssh/gem-private_key.pem') if $PROGRAM_NAME =~ /gem\z/
 
-  s.add_development_dependency 'rake', '>= 12.3.3', '~> 13.0'
-  s.add_development_dependency 'rspec', '~> 3'
-  s.add_development_dependency 'rubocop', '< 1.24'
-  s.add_development_dependency 'rubocop-rake', '~> 0'
-  s.add_development_dependency 'rubocop-rspec', '~> 2'
-  s.add_development_dependency 'simplecov', '~> 0.18'
-  s.add_development_dependency 'simplecov-lcov', '~> 0.8'
-
   s.add_runtime_dependency 'activesupport', '>= 4.1.11', '< 7.0'
   s.add_runtime_dependency 'rack', '>= 2.1.4', '< 2.3.0'
 


### PR DESCRIPTION
Closes: n/a

# Goal

This change clarifies the gemspec to be about the runtime dependencies
only.

What tools are used to test and lint the project is not so important to
the reader of the gemspec.



# Approach
1. Turn the development deps in the gemspec into `gem` lines in the Gemfile.
    1. We only ever use Bundler.
    2. This clarifies and focuses the gemspec file.
